### PR TITLE
Fix property handling in documentation helper

### DIFF
--- a/modoc/doc.py
+++ b/modoc/doc.py
@@ -19,18 +19,19 @@ def get_doc(obj):
 
 
 def _get_class_doc(obj):
-    public_attrs = [attr for attr in dir(obj) if not attr.startswith("_")]
+    public_attrs = [
+        attr
+        for attr in dir(obj)
+        if not attr.startswith("_") and callable(getattr(obj, attr))
+    ]
 
-    return (
-        _get_header_doc(obj, no_docstring_suffix="")
-        + "\n\n"
-        + textwrap.indent(
-            "\n\n".join(
-                _get_fn_doc(getattr(obj, attr)) for attr in public_attrs
-            ),
-            prefix=_INDENT,
-        )
+    header = _get_header_doc(obj, no_docstring_suffix="")
+    body = "\n\n".join(
+        _get_fn_doc(getattr(obj, attr)) for attr in public_attrs
     )
+    if not body:
+        return header
+    return header + "\n\n" + textwrap.indent(body, prefix=_INDENT)
 
 
 def _get_code(obj):
@@ -52,6 +53,14 @@ def _get_header_doc(obj, *, no_docstring_suffix):
     else:
         doclines = 0
         suffix = no_docstring_suffix
-    signature_lines = code_lines[: first_body_thing.lineno - 1 + doclines]
+    end_lineno = first_body_thing.lineno - 1 + doclines
+    if inspect.isclass(obj) and getattr(
+        first_body_thing,
+        "decorator_list",
+        [],
+    ):
+        dec_start = min(d.lineno for d in first_body_thing.decorator_list)
+        end_lineno = dec_start - 1 + doclines
+    signature_lines = code_lines[:end_lineno]
     signature = "\n".join(signature_lines)
     return signature + suffix

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -258,3 +258,19 @@ def test_class_with_non_abstract_methods():
                     """
         ''',
     )
+
+
+def test_class_with_property():
+    class MyClass:
+        @property
+        def value(self):
+            return 5
+
+    doc = get_doc(MyClass)
+
+    _assert_doc(
+        doc,
+        """
+            class MyClass:
+        """,
+    )


### PR DESCRIPTION
## Summary
- skip non-callable attributes when generating class docs
- avoid unnecessary blank lines for classes with no public methods
- detect decorators inside classes when extracting header lines
- add regression test for classes with properties

## Testing
- `ruff check modoc tests`
- `mypy modoc tests`
- `pytest -q`
- `./run_tests.sh` *(fails: could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_683f807b187c8333a5e7d96c11e3dc1e